### PR TITLE
SSL bug

### DIFF
--- a/env-config/config.py
+++ b/env-config/config.py
@@ -106,7 +106,7 @@ MAIL_USERNAME = 'username'
 MAIL_PASSWORD = 'password'
 
 WTF_CSRF_ENABLED = True
-WTF_CSRF_SSL_STRICT = True # Checks Referer Header. Set to False for API access.
+WTF_CSRF_SSL_STRICT = False # Checks Referer Header. Set to False for API access.
 WTF_CSRF_METHODS = ['DELETE', 'POST', 'PUT', 'PATCH']
 
 # "NONE", "SUMMARY", or "FULL"


### PR DESCRIPTION
From http://flask-wtf.readthedocs.io/en/stable/config.html:

```
WTF_CSRF_SSL_STRICT - Whether to enforce the same origin policy by checking that the referrer matches the host. Only applies to HTTPS requests. Default is True.
```

Requests from lambda were being rejected because the requests are not coming from the same origin as the secmonkey app. Turning this setting off fixes the issue.